### PR TITLE
Add trasparent to gray gradient class

### DIFF
--- a/scss/base/_background.scss
+++ b/scss/base/_background.scss
@@ -38,3 +38,7 @@
 .bg-overlay {
   background-blend-mode: overlay;
 }
+
+.bg-gradient-overlay {
+  background: linear-gradient(rgba(0, 0, 0, 0), rgba($gray-800, 0.5));
+}


### PR DESCRIPTION
This class can be used in combination with other bg-{color} classes