### PR TITLE
Add border to btn primary in high contrast

### DIFF
--- a/scss/components/_buttons.scss
+++ b/scss/components/_buttons.scss
@@ -407,3 +407,9 @@ $btn-border-width: 4px;
     }
   }
 }
+
+@media screen and (-ms-high-contrast: active) {
+  .btn-primary {
+    border: 2px solid;
+  }
+}

--- a/scss/components/_buttons.scss
+++ b/scss/components/_buttons.scss
@@ -409,7 +409,7 @@ $btn-border-width: 4px;
 }
 
 @media screen and (-ms-high-contrast: active) {
-  .btn-primary {
-    border: 2px solid;
+  .btn {
+    border: $btn-border-width solid;
   }
 }


### PR DESCRIPTION
This was flagged during accessibility audits: In high contrast mode, the button border is not visible.
Add a border to the `btn-primary` in high contrast mode.