### PR TITLE
Add inline svg to radio btn high contrast

### DIFF
--- a/scss/components/_radio.scss
+++ b/scss/components/_radio.scss
@@ -17,6 +17,7 @@
 
           @media screen and (-ms-high-contrast: active) {
             border-color: Highlight;
+            background-image: url("data:image/svg+xml;charset=utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'><circle r='4' stroke='highlight' stroke-width='1.5' /></svg>");
           }
 
           &::after {
@@ -24,6 +25,7 @@
             
             @media screen and (-ms-high-contrast: active) {
               background-color: Highlight;
+              background-image: url("data:image/svg+xml;charset=utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'><circle r='4' fill='highlight' stroke='window' stroke-width='2' /></svg>");
             }
           }
         }
@@ -38,6 +40,27 @@
             background-color: Window;
           }
         }
+      }
+    }
+
+    &:hover {
+      & + label {
+        .radio-icon {
+
+          @media screen and (-ms-high-contrast: active) {
+            border-color: Highlight;
+            background-image: url("data:image/svg+xml;charset=utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'><circle r='4' stroke='highlight' stroke-width='1.5' /></svg>");
+          }
+
+          &::after {
+            
+            @media screen and (-ms-high-contrast: active) {
+              background-color: Highlight;
+              background-image: url("data:image/svg+xml;charset=utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'><circle r='4' fill='highlight' stroke='window' stroke-width='2' /></svg>");
+            }
+          }
+        }
+
       }
     }
 

--- a/scss/components/_radio.scss
+++ b/scss/components/_radio.scss
@@ -17,7 +17,8 @@
 
           @media screen and (-ms-high-contrast: active) {
             border-color: Highlight;
-            background-image: url("data:image/svg+xml;charset=utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'><circle r='4' stroke='highlight' stroke-width='1.5' /></svg>");
+            border-image: url("data:image/svg+xml;charset=utf8,<svg xmlns='http://www.w3.org/2000/svg'><rect width='100%' height='100%' rx='10' fill='Highlight'/></svg>");
+            border-image-slice: 12;
           }
 
           &::after {
@@ -25,7 +26,7 @@
             
             @media screen and (-ms-high-contrast: active) {
               background-color: Highlight;
-              background-image: url("data:image/svg+xml;charset=utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'><circle r='4' fill='highlight' stroke='window' stroke-width='2' /></svg>");
+              background-image: url("data:image/svg+xml;charset=utf8,<svg xmlns='http://www.w3.org/2000/svg'><rect width='100%' height='100%' fill='Highlight'/></svg>");
             }
           }
         }
@@ -49,14 +50,15 @@
 
           @media screen and (-ms-high-contrast: active) {
             border-color: Highlight;
-            background-image: url("data:image/svg+xml;charset=utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'><circle r='4' stroke='highlight' stroke-width='1.5' /></svg>");
+            border-image: url("data:image/svg+xml;charset=utf8,<svg xmlns='http://www.w3.org/2000/svg'><rect width='100%' height='100%' rx='10' fill='Highlight'/></svg>");
+            border-image-slice: 12;
           }
 
           &::after {
             
             @media screen and (-ms-high-contrast: active) {
               background-color: Highlight;
-              background-image: url("data:image/svg+xml;charset=utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'><circle r='4' fill='highlight' stroke='window' stroke-width='2' /></svg>");
+              background-image: url("data:image/svg+xml;charset=utf8,<svg xmlns='http://www.w3.org/2000/svg'><rect width='100%' height='100%' fill='Highlight'/></svg>");
             }
           }
         }


### PR DESCRIPTION
This was flagged during accessibility audits: Add inline SVG to the radio button on checked and hover in high contrast mode. Since `background-color` and `border-color` properties are not supported in the Edge stable version.

**This fix contains**
- Instead of `background-color` using `background-image` with inline SVG.
- In the SVG adding a circle element since for reflecting the `fill`, it's needed to have `circle`. Referred this [documentation](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/fill)
- Removed previously added border and margin in the CSS.