### PR TITLE
Add border for LinkButton component in high contrast

### DIFF
--- a/scss/components/_buttons.scss
+++ b/scss/components/_buttons.scss
@@ -2,7 +2,8 @@ $btn-border-width: 4px;
 
 @mixin disabled-btn-before {
   &::before {
-    box-shadow: 0 $btn-border-width rgba($white, 0.4) inset,
+    box-shadow:
+      0 $btn-border-width rgba($white, 0.4) inset,
       0 (-$btn-border-width) rgba($black, 0.05) inset,
       $btn-border-width 0 rgba($black, 0.05) inset,
       (-$btn-border-width) 0 rgba($white, 0.4) inset;
@@ -24,7 +25,7 @@ $btn-border-width: 4px;
   display: block;
   width: 100%;
   height: 100%;
-  content: "";
+  content: '';
   transition: 0.7s cubic-bezier(0, 0.8, 0.26, 0.99);
 }
 
@@ -44,7 +45,8 @@ $btn-border-width: 4px;
     &::before,
     .grow {
       background-color: $primary-hover;
-      box-shadow: 0 (-$btn-border-width) rgba($black, 0.35) inset,
+      box-shadow:
+        0 (-$btn-border-width) rgba($black, 0.35) inset,
         0 $btn-border-width rgba($white, 0.25) inset,
         (-$btn-border-width) 0 rgba($white, 0.25) inset,
         $btn-border-width 0 rgba($black, 0.35) inset;
@@ -53,7 +55,8 @@ $btn-border-width: 4px;
 
   &::before,
   .grow {
-    box-shadow: 0 (-$btn-border-width) rgba($black, 0.25) inset,
+    box-shadow:
+      0 (-$btn-border-width) rgba($black, 0.25) inset,
       0 $btn-border-width rgba($white, 0.35) inset,
       (-$btn-border-width) 0 rgba($white, 0.35) inset,
       $btn-border-width 0 rgba($black, 0.25) inset;
@@ -381,7 +384,7 @@ $btn-border-width: 4px;
 }
 
 .btn-disabled-outline,
-[class*="btn-outline"]:disabled {
+[class*=btn-outline]:disabled {
   cursor: default !important;
   color: $gray-300 !important;
   background-color: transparent;
@@ -404,25 +407,32 @@ $btn-border-width: 4px;
     }
   }
 }
+
 @media screen and (-ms-high-contrast: active) {
   .btn {
     border: $btn-border-width solid;
     color: windowText !important;
   }
 
-  a.btn {
-    -ms-high-contrast-adjust: none;
-  }
+  a {
+    &.btn {
+      -ms-high-contrast-adjust: none;
 
-  a.btn::before {
-    background: Window !important;
-    box-shadow: none !important;
-    border-color: HighLight !important;
-  }
+      &::before {
+        background: Window !important;
+        box-shadow: none !important;
+        border-color: HighLight !important;
+      }
 
-  a.btn:hover {
-    border-color: HighLight !important;
-    box-shadow: none !important;
-    color: windowText !important;
+      &:hover {
+        border-color: HighLight !important;
+        box-shadow: none !important;
+        color: windowText !important;
+
+        &::before {
+          background-color: Window !important;
+        }
+      }
+    }
   }
 }

--- a/scss/components/_buttons.scss
+++ b/scss/components/_buttons.scss
@@ -2,8 +2,7 @@ $btn-border-width: 4px;
 
 @mixin disabled-btn-before {
   &::before {
-    box-shadow:
-      0 $btn-border-width rgba($white, 0.4) inset,
+    box-shadow: 0 $btn-border-width rgba($white, 0.4) inset,
       0 (-$btn-border-width) rgba($black, 0.05) inset,
       $btn-border-width 0 rgba($black, 0.05) inset,
       (-$btn-border-width) 0 rgba($white, 0.4) inset;
@@ -25,7 +24,7 @@ $btn-border-width: 4px;
   display: block;
   width: 100%;
   height: 100%;
-  content: '';
+  content: "";
   transition: 0.7s cubic-bezier(0, 0.8, 0.26, 0.99);
 }
 
@@ -45,8 +44,7 @@ $btn-border-width: 4px;
     &::before,
     .grow {
       background-color: $primary-hover;
-      box-shadow:
-        0 (-$btn-border-width) rgba($black, 0.35) inset,
+      box-shadow: 0 (-$btn-border-width) rgba($black, 0.35) inset,
         0 $btn-border-width rgba($white, 0.25) inset,
         (-$btn-border-width) 0 rgba($white, 0.25) inset,
         $btn-border-width 0 rgba($black, 0.35) inset;
@@ -55,8 +53,7 @@ $btn-border-width: 4px;
 
   &::before,
   .grow {
-    box-shadow:
-      0 (-$btn-border-width) rgba($black, 0.25) inset,
+    box-shadow: 0 (-$btn-border-width) rgba($black, 0.25) inset,
       0 $btn-border-width rgba($white, 0.35) inset,
       (-$btn-border-width) 0 rgba($white, 0.35) inset,
       $btn-border-width 0 rgba($black, 0.25) inset;
@@ -384,7 +381,7 @@ $btn-border-width: 4px;
 }
 
 .btn-disabled-outline,
-[class*=btn-outline]:disabled {
+[class*="btn-outline"]:disabled {
   cursor: default !important;
   color: $gray-300 !important;
   background-color: transparent;
@@ -407,9 +404,25 @@ $btn-border-width: 4px;
     }
   }
 }
-
 @media screen and (-ms-high-contrast: active) {
   .btn {
     border: $btn-border-width solid;
+    color: windowText !important;
+  }
+
+  a.btn {
+    -ms-high-contrast-adjust: none;
+  }
+
+  a.btn::before {
+    background: Window !important;
+    box-shadow: none !important;
+    border-color: HighLight !important;
+  }
+
+  a.btn:hover {
+    border-color: HighLight !important;
+    box-shadow: none !important;
+    color: windowText !important;
   }
 }

--- a/scss/components/_radio.scss
+++ b/scss/components/_radio.scss
@@ -2,6 +2,10 @@
   display: inline-block;
   position: relative;
 
+  @media screen and (-ms-high-contrast: active) {
+    -ms-high-contrast-adjust: none;
+  }
+
   input[type="radio"] {
     position: absolute;
     top: 0;
@@ -129,5 +133,10 @@
     border-radius: 4px;
     padding: $spacer;
     transition: 0.3s;
+
+    @media screen and (-ms-high-contrast: active) {
+      border-color: windowText;
+      box-shadow: none !important;
+    }
   }
 }


### PR DESCRIPTION
This was flagged during accessibility audits: 
Add rules for showing linkbutton components as normal buttons using `-ms-high-contrast: active` media query. 
Add rules for fixing fucntionality of radio buttons in high contrast mode `-ms-high-contrast: active` media query.

Default behaviour for `<a>` tag is just to show in yellow color.

Default behaviour of radio buttons is overriding the custom class written for custom radio buttons.

Fix contains:

1. Uses `-ms-high-contrast-adjust: none;` to disable default behaviour anchor tags in contrast mode and update the design.
2. Rules to add border color and text color and background color for buttons using anchor tags in `<LinkButton>` components.
3. Rules to disable default radio button behaviour using `-ms-high-contrast-adjust: none;` for the `.radio` class.
4. Rules to add border and disable box shadow to `.radio-selection` class in high contrast mode.

Files Changed: 
`scss/components/_buttons.scss`
`scss/components/_radio.scss`



Solutions works in both IE and Edge(Chromium).