### PR TITLE
Add highlight color on focus for linkbutton

### DIFF
--- a/scss/components/_buttons.scss
+++ b/scss/components/_buttons.scss
@@ -433,6 +433,12 @@ $btn-border-width: 4px;
           background-color: Window !important;
         }
       }
+
+      &:focus {
+        border-color: HighLight !important;
+        box-shadow: none !important;
+        color: windowText !important;
+      }
     }
   }
 }


### PR DESCRIPTION
This was flagged during accessibility audits:
Add rules for showing highlight on linkbutton components while on focus.

Fix contains:
1. Rules to add border and background for focus selector

Files Changed:
`scss/components/_buttons.scss`