### PR TITLE
Add box shadow on focus for disabled button

### DIFF
--- a/scss/components/_buttons.scss
+++ b/scss/components/_buttons.scss
@@ -382,7 +382,7 @@ $btn-border-width: 4px;
     color: $gray-600 !important;
   }
   &:focus{
-    box-shadow: 0 0 3px 1px #397ad1, 0 0 2px 1px #397ad1 inset;
+    box-shadow: $btn-focus-box-shadow;
   }
 }
 

--- a/scss/components/_buttons.scss
+++ b/scss/components/_buttons.scss
@@ -381,6 +381,9 @@ $btn-border-width: 4px;
     @include disabled-btn-after;
     color: $gray-600 !important;
   }
+  &:focus{
+    box-shadow: 0 0 3px 1px #397ad1, 0 0 2px 1px #397ad1 inset;
+  }
 }
 
 .btn-disabled-outline,

--- a/scss/components/_navbar.scss
+++ b/scss/components/_navbar.scss
@@ -85,6 +85,15 @@
       color: $nav-link-disabled-color !important;
     }
   }
+  @media screen and (-ms-high-contrast: active) {
+    -ms-high-contrast-adjust: none;
+    color: windowText !important;
+    &.active,
+    &:hover {
+      color: window !important;
+      background-color: HighLight !important;
+    }
+  }
 }
 
 .nav {


### PR DESCRIPTION
Fix Contains:
- `box-shadow` css rule for disabled buttons to show proper focus boundary.
- Disable browser anchor tag styles for high contrast.
- Add styles for `.nav-link` in `active `and `hover` for high contrast mode.

Files Changed:
`scss/components/_buttons.scss`
`scss/components/_navbar.scss`

Bugs: 381157, 381338